### PR TITLE
Adds optional parameters to async_request: record_type and load_from_cache

### DIFF
--- a/src/zeroconf/__init__.py
+++ b/src/zeroconf/__init__.py
@@ -35,6 +35,7 @@ from ._dns import (  # noqa # import needed for backwards compat
     DNSRecord,
     DNSService,
     DNSText,
+    DNSRecordType,
 )
 from ._exceptions import (
     AbstractMethodException,

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -61,6 +61,22 @@ class DNSQuestionType(enum.Enum):
     QM = 2
 
 
+@enum.unique
+class DNSRecordType(enum.Enum):
+    """An MDNS record type.
+
+    "A" - A MDNS record type
+    "AAAA" - AAAA MDNS record type
+    "SRV" - SRV MDNS record type
+    "TXT" - TXT MDNS record type
+    """
+
+    A = 0
+    AAAA = 1
+    SRV = 2
+    TXT = 3
+
+
 class DNSEntry:
 
     """A DNS entry"""

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -36,6 +36,7 @@ from .._dns import (
     DNSRecord,
     DNSService,
     DNSText,
+    DNSRecordType
 )
 from .._exceptions import BadTypeInNameException
 from .._history import QuestionHistory
@@ -882,7 +883,7 @@ class ServiceInfo(RecordUpdateListener):
             out.add_answer_at_time(answer, now)
 
     def _generate_request_query(
-        self, zc: 'Zeroconf', now: float_, question_type: DNSQuestionType
+        self, zc: 'Zeroconf', now: float_, question_type: DNSQuestionType, record_type: DNSRecordType
     ) -> DNSOutgoing:
         """Generate the request query."""
         out = DNSOutgoing(_FLAGS_QR_QUERY)
@@ -891,18 +892,26 @@ class ServiceInfo(RecordUpdateListener):
         cache = zc.cache
         history = zc.question_history
         qu_question = question_type is QU_QUESTION
-        self._add_question_with_known_answers(
-            out, qu_question, history, cache, now, name, _TYPE_SRV, _CLASS_IN, True
-        )
-        self._add_question_with_known_answers(
-            out, qu_question, history, cache, now, name, _TYPE_TXT, _CLASS_IN, True
-        )
-        self._add_question_with_known_answers(
-            out, qu_question, history, cache, now, server, _TYPE_A, _CLASS_IN, False
-        )
-        self._add_question_with_known_answers(
-            out, qu_question, history, cache, now, server, _TYPE_AAAA, _CLASS_IN, False
-        )
+        if record_type is None or record_type is DNSRecordType.SRV:
+            print("Requesting MDNS SRV record...")
+            self._add_question_with_known_answers(
+                out, qu_question, history, cache, now, name, _TYPE_SRV, _CLASS_IN, True
+            )
+        if record_type is None or record_type is DNSRecordType.TXT:
+            print("Requesting MDNS TXT record...")
+            self._add_question_with_known_answers(
+                out, qu_question, history, cache, now, name, _TYPE_TXT, _CLASS_IN, True
+            )
+        if record_type is None or record_type is DNSRecordType.A:
+            print("Requesting MDNS A record...")
+            self._add_question_with_known_answers(
+                out, qu_question, history, cache, now, server, _TYPE_A, _CLASS_IN, False
+            )
+        if record_type is None or record_type is DNSRecordType.AAAA:
+            print("Requesting MDNS AAAA record...")
+            self._add_question_with_known_answers(
+                out, qu_question, history, cache, now, server, _TYPE_AAAA, _CLASS_IN, False
+            )
         return out
 
     def __repr__(self) -> str:

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -794,6 +794,7 @@ class ServiceInfo(RecordUpdateListener):
         question_type: Optional[DNSQuestionType] = None,
         addr: Optional[str] = None,
         port: int = _MDNS_PORT,
+        record_type: DNSRecordType = None
     ) -> bool:
         """Returns true if the service could be discovered on the
         network, and updates this object with details discovered.
@@ -827,7 +828,7 @@ class ServiceInfo(RecordUpdateListener):
                     return False
                 if next_ <= now:
                     this_question_type = question_type or QU_QUESTION if first_request else QM_QUESTION
-                    out = self._generate_request_query(zc, now, this_question_type)
+                    out = self._generate_request_query(zc, now, this_question_type, record_type)
                     first_request = False
                     if out.questions:
                         # All questions may have been suppressed

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -794,7 +794,8 @@ class ServiceInfo(RecordUpdateListener):
         question_type: Optional[DNSQuestionType] = None,
         addr: Optional[str] = None,
         port: int = _MDNS_PORT,
-        record_type: DNSRecordType = None
+        record_type: DNSRecordType = None,
+        load_from_cache: bool = True
     ) -> bool:
         """Returns true if the service could be discovered on the
         network, and updates this object with details discovered.
@@ -811,8 +812,9 @@ class ServiceInfo(RecordUpdateListener):
 
         now = current_time_millis()
 
-        if self._load_from_cache(zc, now):
-            return True
+        if load_from_cache:
+            if self._load_from_cache(zc, now):
+                return True
 
         if TYPE_CHECKING:
             assert zc.loop is not None


### PR DESCRIPTION
Adds optional parameters to **async_request**:

- record_type: Defaults to **None**.
- load_from_cache: Defaults to **True**.

If **record_type** is set, zeroconf will only generate questions for the specified record type (A, AAAA, SRV, or TXT), if not , it will generate questions for all types _(default zeroconf behavior)._

if **load_from_cache** is set to **False**, it will perform a fresh fetch, if set to **True** or unset, it will pull from the cache _(default zeroconf behavior)._